### PR TITLE
Temporarily remove breaking steps of deployment actions

### DIFF
--- a/.github/workflows/dev-cd.yaml
+++ b/.github/workflows/dev-cd.yaml
@@ -37,67 +37,60 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: yarn build
 
-      - name: Pin to IPFS
-        id: upload
-        uses: anantaramdas/ipfs-pinata-deploy-action@39bbda1ce1fe24c69c6f57861b8038278d53688d
-        with:
-          pin-name: Zodiac Roles App - Latest — ${ GITHUB_SHA }
-          path: "./packages/app/build"
-          pinata-api-key: ${{ secrets.PINATA_API_KEY }}
-          pinata-secret-api-key: ${{ secrets.PINATA_API_SECRET_KEY }}
+      # - name: Pin to IPFS
+      #   id: upload
+      #   uses: anantaramdas/ipfs-pinata-deploy-action@39bbda1ce1fe24c69c6f57861b8038278d53688d
+      #   with:
+      #     pin-name: Zodiac Roles App - Latest — ${ GITHUB_SHA }
+      #     path: "./packages/app/build"
+      #     verbose: true
+      #     pinata-api-key: ${{ secrets.PINATA_API_KEY }}
+      #     pinata-secret-api-key: ${{ secrets.PINATA_API_SECRET_KEY }}
 
-      - name: Pin to Crust
-        uses: crustio/ipfs-crust-action@v2.0.3
-        continue-on-error: true
-        timeout-minutes: 2
-        with:
-          cid: ${{ steps.upload.outputs.hash }}
-          seeds: ${{ secrets.CRUST_SEEDS }}
+      # - name: Convert CIDv0 to CIDv1
+      #   id: convert_cidv0
+      #   uses: uniswap/convert-cidv0-cidv1@v1.0.0
+      #   with:
+      #     cidv0: ${{ steps.upload.outputs.hash }}
 
-      - name: Convert CIDv0 to CIDv1
-        id: convert_cidv0
-        uses: uniswap/convert-cidv0-cidv1@v1.0.0
-        with:
-          cidv0: ${{ steps.upload.outputs.hash }}
+      # - name: Update DNS with new IPFS hash
+      #   env:
+      #     CLOUDFLARE_TOKEN: ${{ secrets.CLOUDFLARE_TOKEN }}
+      #     RECORD_DOMAIN: "gnosisguild.org"
+      #     RECORD_NAME: "_dnslink.roles.dev"
+      #     CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+      #   uses: textileio/cloudflare-update-dnslink@0fe7b7a1ffc865db3a4da9773f0f987447ad5848
+      #   with:
+      #     cid: ${{ steps.upload.outputs.hash }}
 
-      - name: Update DNS with new IPFS hash
-        env:
-          CLOUDFLARE_TOKEN: ${{ secrets.CLOUDFLARE_TOKEN }}
-          RECORD_DOMAIN: "gnosisguild.org"
-          RECORD_NAME: "_dnslink.roles.dev"
-          CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
-        uses: textileio/cloudflare-update-dnslink@0fe7b7a1ffc865db3a4da9773f0f987447ad5848
-        with:
-          cid: ${{ steps.upload.outputs.hash }}
+      # - name: Get IPFS url
+      #   run: echo "IPFS gateways — https://${{ steps.convert_cidv0.outputs.cidv1 }}.ipfs.dweb.link/ or https://${{ steps.convert_cidv0.outputs.cidv1 }}.ipfs.cf-ipfs.com/"
 
-      - name: Get IPFS url
-        run: echo "IPFS gateways — https://${{ steps.convert_cidv0.outputs.cidv1 }}.ipfs.dweb.link/ or https://${{ steps.convert_cidv0.outputs.cidv1 }}.ipfs.cf-ipfs.com/"
+      # - name: Prep graph cli for deployment
+      #   working-directory: packages/subgraph
+      #   run: yarn run graph auth --product hosted-service ${{ secrets.GRAPH_ACCESS_TOKEN }}
 
-      - name: Prep graph cli for deployment
-        working-directory: packages/subgraph
-        run: yarn run graph auth --product hosted-service ${{ secrets.GRAPH_ACCESS_TOKEN }}
-
-      - name: Deploy subgraphs
-        working-directory: packages/subgraph
-        env:
-          HOSTED_SERVICE_SUBGRAPH__GNOSIS_CHAIN: samepant/zodiac-roles-mod-gnosis-chain
-          HOSTED_SERVICE_SUBGRAPH__ARBITRUM_ONE: samepant/zodiac-roles-mod-arbitrum
-          HOSTED_SERVICE_SUBGRAPH__GOERLI: samepant/zodiac-roles-mod-goerli
-          HOSTED_SERVICE_SUBGRAPH__SEPOLIA: samepant/zodiac-roles-mod-sepolia
-          HOSTED_SERVICE_SUBGRAPH__AVALANCHE: samepant/zodiac-roles-mod-avalanche
-          HOSTED_SERVICE_SUBGRAPH__BSC: samepant/zodiac-roles-mod-bsc
-          HOSTED_SERVICE_SUBGRAPH__MAINNET: samepant/zodiac-roles-mod-mainnet
-          HOSTED_SERVICE_SUBGRAPH__OPTIMISM: samepant/zodiac-roles-mod-optimism
-          HOSTED_SERVICE_SUBGRAPH__POLYGON: samepant/zodiac-roles-mod-polygon
-          # HOSTED_SERVICE_SUBGRAPH__OPTIMISM_ON_GNOSIS_CHAIN: samepant/zodiac-roles-mod_optimism-on-gnosis-chain
-        run: |
-          yarn deploy:arbitrum-one
-          yarn deploy:gnosis-chain
-          yarn deploy:goerli
-          yarn deploy:sepolia
-          yarn deploy:avalanche
-          yarn deploy:bsc
-          yarn deploy:mainnet
-          yarn deploy:optimism
-          yarn deploy:polygon
-          # yarn deploy:optimism-on-gnosis-chain
+      # - name: Deploy subgraphs
+      #   working-directory: packages/subgraph
+      #   env:
+      #     HOSTED_SERVICE_SUBGRAPH__GNOSIS_CHAIN: samepant/zodiac-roles-mod-gnosis-chain
+      #     HOSTED_SERVICE_SUBGRAPH__ARBITRUM_ONE: samepant/zodiac-roles-mod-arbitrum
+      #     HOSTED_SERVICE_SUBGRAPH__GOERLI: samepant/zodiac-roles-mod-goerli
+      #     HOSTED_SERVICE_SUBGRAPH__SEPOLIA: samepant/zodiac-roles-mod-sepolia
+      #     HOSTED_SERVICE_SUBGRAPH__AVALANCHE: samepant/zodiac-roles-mod-avalanche
+      #     HOSTED_SERVICE_SUBGRAPH__BSC: samepant/zodiac-roles-mod-bsc
+      #     HOSTED_SERVICE_SUBGRAPH__MAINNET: samepant/zodiac-roles-mod-mainnet
+      #     HOSTED_SERVICE_SUBGRAPH__OPTIMISM: samepant/zodiac-roles-mod-optimism
+      #     HOSTED_SERVICE_SUBGRAPH__POLYGON: samepant/zodiac-roles-mod-polygon
+      #     # HOSTED_SERVICE_SUBGRAPH__OPTIMISM_ON_GNOSIS_CHAIN: samepant/zodiac-roles-mod_optimism-on-gnosis-chain
+      #   run: |
+      #     yarn deploy:arbitrum-one
+      #     yarn deploy:gnosis-chain
+      #     yarn deploy:goerli
+      #     yarn deploy:sepolia
+      #     yarn deploy:avalanche
+      #     yarn deploy:bsc
+      #     yarn deploy:mainnet
+      #     yarn deploy:optimism
+      #     yarn deploy:polygon
+      #     # yarn deploy:optimism-on-gnosis-chain

--- a/.github/workflows/prod-release-deploy.yaml
+++ b/.github/workflows/prod-release-deploy.yaml
@@ -37,55 +37,47 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: yarn build
 
-      - name: Pin to IPFS
-        id: upload
-        uses: anantaramdas/ipfs-pinata-deploy-action@39bbda1ce1fe24c69c6f57861b8038278d53688d
-        with:
-          pin-name: Zodiac Roles App - Prod — ${ GITHUB_SHA }
-          path: "./packages/app/build"
-          pinata-api-key: ${{ secrets.PINATA_API_KEY }}
-          pinata-secret-api-key: ${{ secrets.PINATA_API_SECRET_KEY }}
+      # - name: Pin to IPFS
+      #   id: upload
+      #   uses: anantaramdas/ipfs-pinata-deploy-action@39bbda1ce1fe24c69c6f57861b8038278d53688d
+      #   with:
+      #     pin-name: Zodiac Roles App - Prod — ${ GITHUB_SHA }
+      #     path: "./packages/app/build"
+      #     pinata-api-key: ${{ secrets.PINATA_API_KEY }}
+      #     pinata-secret-api-key: ${{ secrets.PINATA_API_SECRET_KEY }}
 
-      - name: Pin to Crust
-        uses: crustio/ipfs-crust-action@v2.0.3
-        continue-on-error: true
-        timeout-minutes: 2
-        with:
-          cid: ${{ steps.upload.outputs.hash }}
-          seeds: ${{ secrets.CRUST_SEEDS }}
+      # - name: Convert CIDv0 to CIDv1
+      #   id: convert_cidv0
+      #   uses: uniswap/convert-cidv0-cidv1@v1.0.0
+      #   with:
+      #     cidv0: ${{ steps.upload.outputs.hash }}
 
-      - name: Convert CIDv0 to CIDv1
-        id: convert_cidv0
-        uses: uniswap/convert-cidv0-cidv1@v1.0.0
-        with:
-          cidv0: ${{ steps.upload.outputs.hash }}
+      # - name: Update DNS with new IPFS hash
+      #   env:
+      #     CLOUDFLARE_TOKEN: ${{ secrets.CLOUDFLARE_TOKEN }}
+      #     RECORD_DOMAIN: "gnosisguild.org"
+      #     RECORD_NAME: "_dnslink.roles"
+      #     CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+      #   uses: textileio/cloudflare-update-dnslink@0fe7b7a1ffc865db3a4da9773f0f987447ad5848
+      #   with:
+      #     cid: ${{ steps.upload.outputs.hash }}
 
-      - name: Update DNS with new IPFS hash
-        env:
-          CLOUDFLARE_TOKEN: ${{ secrets.CLOUDFLARE_TOKEN }}
-          RECORD_DOMAIN: "gnosisguild.org"
-          RECORD_NAME: "_dnslink.roles"
-          CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
-        uses: textileio/cloudflare-update-dnslink@0fe7b7a1ffc865db3a4da9773f0f987447ad5848
-        with:
-          cid: ${{ steps.upload.outputs.hash }}
+      # - name: update release
+      #   id: update_release
+      #   uses: tubone24/update_release@v1.3.1
+      #   env:
+      #     GITHUB_TOKEN: ${{ github.token }}
+      #   with:
+      #     is_append_body: true
+      #     body: |
+      #       <br />
+      #       IPFS hash of the deployment:
+      #       - CIDv0: `${{ steps.upload.outputs.hash }}`
+      #       - CIDv1: `${{ steps.convert_cidv0.outputs.cidv1 }}`
 
-      - name: update release
-        id: update_release
-        uses: tubone24/update_release@v1.3.1
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        with:
-          is_append_body: true
-          body: |
-            <br />
-            IPFS hash of the deployment:
-            - CIDv0: `${{ steps.upload.outputs.hash }}`
-            - CIDv1: `${{ steps.convert_cidv0.outputs.cidv1 }}`
-
-            IPFS gateways:
-              - https://${{ steps.convert_cidv0.outputs.cidv1 }}.ipfs.dweb.link/
-              - https://${{ steps.convert_cidv0.outputs.cidv1 }}.ipfs.cf-ipfs.com/
+      #       IPFS gateways:
+      #         - https://${{ steps.convert_cidv0.outputs.cidv1 }}.ipfs.dweb.link/
+      #         - https://${{ steps.convert_cidv0.outputs.cidv1 }}.ipfs.cf-ipfs.com/
 
       - name: Deploy to Github Pages
         uses: JamesIves/github-pages-deploy-action@v4.3.3
@@ -93,31 +85,31 @@ jobs:
           branch: gh-pages
           folder: ./packages/app/build
 
-      - name: Prep graph cli for deployment
-        working-directory: packages/subgraph
-        run: yarn run graph auth --product hosted-service ${{ secrets.GRAPH_ACCESS_TOKEN }}
+      # - name: Prep graph cli for deployment
+      #   working-directory: packages/subgraph
+      #   run: yarn run graph auth --product hosted-service ${{ secrets.GRAPH_ACCESS_TOKEN }}
 
-      - name: Deploy subgraphs
-        working-directory: packages/subgraph
-        env:
-          HOSTED_SERVICE_SUBGRAPH__GNOSIS_CHAIN: samepant/zodiac-roles-mod-gnosis-chain
-          HOSTED_SERVICE_SUBGRAPH__ARBITRUM_ONE: samepant/zodiac-roles-mod-arbitrum
-          HOSTED_SERVICE_SUBGRAPH__GOERLI: samepant/zodiac-roles-mod-goerli
-          HOSTED_SERVICE_SUBGRAPH__SEPOLIA: samepant/zodiac-roles-mod-sepolia
-          HOSTED_SERVICE_SUBGRAPH__AVALANCHE: samepant/zodiac-roles-mod-avalanche
-          HOSTED_SERVICE_SUBGRAPH__BSC: samepant/zodiac-roles-mod-bsc
-          HOSTED_SERVICE_SUBGRAPH__MAINNET: samepant/zodiac-roles-mod-mainnet
-          HOSTED_SERVICE_SUBGRAPH__OPTIMISM: samepant/zodiac-roles-mod-optimism
-          HOSTED_SERVICE_SUBGRAPH__POLYGON: samepant/zodiac-roles-mod-polygon
-          # HOSTED_SERVICE_SUBGRAPH__OPTIMISM_ON_GNOSIS_CHAIN: samepant/zodiac-roles-mod_optimism-on-gnosis-chain
-        run: |
-          yarn deploy:arbitrum-one
-          yarn deploy:gnosis-chain
-          yarn deploy:goerli
-          yarn deploy:sepolia
-          yarn deploy:avalanche
-          yarn deploy:bsc
-          yarn deploy:mainnet
-          yarn deploy:optimism
-          yarn deploy:polygon
-          # yarn deploy:optimism-on-gnosis-chain
+      # - name: Deploy subgraphs
+      #   working-directory: packages/subgraph
+      #   env:
+      #     HOSTED_SERVICE_SUBGRAPH__GNOSIS_CHAIN: samepant/zodiac-roles-mod-gnosis-chain
+      #     HOSTED_SERVICE_SUBGRAPH__ARBITRUM_ONE: samepant/zodiac-roles-mod-arbitrum
+      #     HOSTED_SERVICE_SUBGRAPH__GOERLI: samepant/zodiac-roles-mod-goerli
+      #     HOSTED_SERVICE_SUBGRAPH__SEPOLIA: samepant/zodiac-roles-mod-sepolia
+      #     HOSTED_SERVICE_SUBGRAPH__AVALANCHE: samepant/zodiac-roles-mod-avalanche
+      #     HOSTED_SERVICE_SUBGRAPH__BSC: samepant/zodiac-roles-mod-bsc
+      #     HOSTED_SERVICE_SUBGRAPH__MAINNET: samepant/zodiac-roles-mod-mainnet
+      #     HOSTED_SERVICE_SUBGRAPH__OPTIMISM: samepant/zodiac-roles-mod-optimism
+      #     HOSTED_SERVICE_SUBGRAPH__POLYGON: samepant/zodiac-roles-mod-polygon
+      #     # HOSTED_SERVICE_SUBGRAPH__OPTIMISM_ON_GNOSIS_CHAIN: samepant/zodiac-roles-mod_optimism-on-gnosis-chain
+      #   run: |
+      #     yarn deploy:arbitrum-one
+      #     yarn deploy:gnosis-chain
+      #     yarn deploy:goerli
+      #     yarn deploy:sepolia
+      #     yarn deploy:avalanche
+      #     yarn deploy:bsc
+      #     yarn deploy:mainnet
+      #     yarn deploy:optimism
+      #     yarn deploy:polygon
+      #     # yarn deploy:optimism-on-gnosis-chain


### PR DESCRIPTION
Pinata recently removed the ability to upload/pin HTML files without special permission granted on your account. We are currently waiting on them to enable our account.

Once we are enabled, i'll add back in these steps.